### PR TITLE
AutocompleteController Get 메서드 매개변수 값 검사

### DIFF
--- a/Server/Controllers/AutocompleteController.cs
+++ b/Server/Controllers/AutocompleteController.cs
@@ -25,6 +25,11 @@ namespace Server.Controllers
         [HttpGet]
         public ActionResult<IEnumerable<PlayerSummary>> Get([FromQuery] string keyword)
         {
+            if (string.IsNullOrEmpty(keyword) || 12 < keyword.Length)
+            {
+                return BadRequest();
+            }
+
             var playerSummarys = _appDbContext.PlayerSummary.FromSqlInterpolated($"CALL GetPlayerSummarys({keyword})")
                 .AsEnumerable();
             return Ok(playerSummarys);

--- a/Server/Controllers/AutocompleteController.cs
+++ b/Server/Controllers/AutocompleteController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Server.Controllers
 {
@@ -22,13 +23,11 @@ namespace Server.Controllers
             _appDbContext = appDbContext;
         }
         [HttpGet]
-        public async IAsyncEnumerable<PlayerSummary> Get([FromQuery] string keyword)
+        public ActionResult<IEnumerable<PlayerSummary>> Get([FromQuery] string keyword)
         {
-            var playerSummarys = _appDbContext.PlayerSummary.FromSqlInterpolated($"CALL GetPlayerSummarys({keyword})").AsAsyncEnumerable();
-            await foreach (var playerSummary in playerSummarys)
-            {
-                yield return playerSummary;
-            }
+            var playerSummarys = _appDbContext.PlayerSummary.FromSqlInterpolated($"CALL GetPlayerSummarys({keyword})")
+                .AsEnumerable();
+            return Ok(playerSummarys);
         }
     }
 }

--- a/Server/Controllers/AutocompleteController.cs
+++ b/Server/Controllers/AutocompleteController.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore;
 
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Http;
 
 namespace Server.Controllers
 {
@@ -23,6 +24,8 @@ namespace Server.Controllers
             _appDbContext = appDbContext;
         }
         [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<PlayerSummary>))]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public ActionResult<IEnumerable<PlayerSummary>> Get([FromQuery] string keyword)
         {
             if (string.IsNullOrEmpty(keyword) || 12 < keyword.Length)


### PR DESCRIPTION
매개변수 `keyword`가 `null`이거나 길이 12 초과일 때 `BadRequest` 리턴